### PR TITLE
Adjust Scarecrow Logic to Properly Push Animals Away in a Radius of Five Blocks

### DIFF
--- a/src/main/java/com/mrbysco/enhancedfarming/blockentity/ScarecrowBlockEntity.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/blockentity/ScarecrowBlockEntity.java
@@ -24,7 +24,7 @@ public class ScarecrowBlockEntity extends BlockEntity {
 		super(blockEntityType, pos, state);
 		this.hitbox = new AABB(pos.getX() - 0.5f, pos.getY() - 0.5f, pos.getZ() - 0.5f,
 				pos.getX() + 0.5f, pos.getY() + 0.5f, pos.getZ() + 0.5f)
-				.inflate(-5, -5, -5).inflate(5, 5, 5);
+				.inflate(5, 5, 5);
 	}
 
 	public ScarecrowBlockEntity(BlockPos pos, BlockState state) {
@@ -36,22 +36,20 @@ public class ScarecrowBlockEntity extends BlockEntity {
 			if (level.getGameTime() % 10 == 0) {
 				blockEntity.entityList.clear();
 				blockEntity.entityList.addAll(level.getEntitiesOfClass(PathfinderMob.class, blockEntity.hitbox).stream()
-						.filter(entity -> entity instanceof Animal || entity instanceof WaterAnimal).map(entity -> entity).toList());
+						.filter(entity -> entity instanceof Animal || entity instanceof WaterAnimal).toList());
 			}
 
-			if (blockEntity.entityList != null && !blockEntity.entityList.isEmpty()) {
-				for (PathfinderMob animal : blockEntity.entityList) {
-					final Vec3 animalPos = getInvertedDirection(pos, animal);
-					animal.moveRelative(0.05F, animalPos);
-				}
+			for (PathfinderMob animal : blockEntity.entityList) {
+				final Vec3 animalPos = getInvertedDirection(pos, animal);
+				animal.setDeltaMovement(animal.getDeltaMovement().add(animalPos));
 			}
 		}
 	}
 
 	public static Vec3 getInvertedDirection(BlockPos scarecrow, Entity animal) {
-		double x = (animal.getX() < scarecrow.getX() ? 1 : 0);
-		double z = (animal.getZ() < scarecrow.getZ() ? 1 : 0);
+		Vec3 dir = animal.position().subtract(scarecrow.getX(), 0, scarecrow.getZ())
+				.normalize().scale(1.5);
 
-		return new Vec3(animal.getX() + x, 0.5, animal.getZ() + z);
+		return new Vec3(dir.x(), 0, dir.z());
 	}
 }

--- a/src/main/java/com/mrbysco/enhancedfarming/blockentity/ScarecrowBlockEntity.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/blockentity/ScarecrowBlockEntity.java
@@ -47,9 +47,7 @@ public class ScarecrowBlockEntity extends BlockEntity {
 	}
 
 	public static Vec3 getInvertedDirection(BlockPos scarecrow, Entity animal) {
-		Vec3 dir = animal.position().subtract(scarecrow.getX(), 0, scarecrow.getZ())
-				.normalize().scale(1.5);
-
-		return new Vec3(dir.x(), 0, dir.z());
+		return animal.position().subtract(scarecrow.getX(), scarecrow.getY(), scarecrow.getZ())
+				.normalize().scale(0.1);
 	}
 }

--- a/src/main/java/com/mrbysco/enhancedfarming/blockentity/ScarecrowBlockEntity.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/blockentity/ScarecrowBlockEntity.java
@@ -24,7 +24,7 @@ public class ScarecrowBlockEntity extends BlockEntity {
 		super(blockEntityType, pos, state);
 		this.hitbox = new AABB(pos.getX() - 0.5f, pos.getY() - 0.5f, pos.getZ() - 0.5f,
 				pos.getX() + 0.5f, pos.getY() + 0.5f, pos.getZ() + 0.5f)
-				.inflate(5, 5, 5);
+				.inflate(5);
 	}
 
 	public ScarecrowBlockEntity(BlockPos pos, BlockState state) {


### PR DESCRIPTION
Closes #23 

This cleans up some of the math used to determine how an entity is pushed away by the scarecrow, including some general code restructures.

### AABB#inflate

Inflate works by increasing *all* bounds by the specific number. So, there is no need to set it for both negative and positive values, unless you wanted the bounds to have a radius of 10.

### Identity Map

Identity map does nothing unless you want a specific object stream, so it was removed.

### List checks

The list is always present and can be looped through even if empty, so the if statement is unnecessary.

### Pushing Math

The pushing logic should push all entities in the opposite direction the scarecrow. However, `#moveRelative` pushes the entity based on the y rotation of the body, which sometime leads to the entity being pushed towards the scarecrow or even around it. This replaces the logic by setting the velocity directly by pushing the entity. Also, pushing has been added in the y direction as well for flying and burrowing entities.