### PR TITLE
1.21.1 Fix negative dropModifier from Rake causing bound to be negative throwing IllegalArgumentException

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ curseforge_id=285105
 modrinth_id=7NG8HLUy
 
 # Version
-version=6.0.2
+version=6.0.3
 
 # Dependencies
 jei_version=19.19.4.230

--- a/src/main/java/com/mrbysco/enhancedfarming/init/FarmingRegistry.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/init/FarmingRegistry.java
@@ -206,10 +206,10 @@ public class FarmingRegistry {
 
 	//Rakes
 	public static final DeferredItem<RakeToolItem> WOODEN_RAKE = ITEMS.register("wooden_rake", () -> new RakeToolItem(Tiers.WOOD, 0, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, -3.0F, 1))));
-	public static final DeferredItem<RakeToolItem> STONE_RAKE = ITEMS.register("stone_rake", () -> new RakeToolItem(Tiers.STONE, -1, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, -2.0F, 2))));
-	public static final DeferredItem<RakeToolItem> IRON_RAKE = ITEMS.register("iron_rake", () -> new RakeToolItem(Tiers.IRON, -2, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, -1.0F, 3))));
+	public static final DeferredItem<RakeToolItem> STONE_RAKE = ITEMS.register("stone_rake", () -> new RakeToolItem(Tiers.STONE, 1, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, -2.0F, 2))));
+	public static final DeferredItem<RakeToolItem> IRON_RAKE = ITEMS.register("iron_rake", () -> new RakeToolItem(Tiers.IRON, 2, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, -1.0F, 3))));
 	public static final DeferredItem<RakeToolItem> GOLD_RAKE = ITEMS.register("gold_rake", () -> new RakeToolItem(Tiers.GOLD, 0, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, -3.0F, 6))));
-	public static final DeferredItem<RakeToolItem> DIAMOND_RAKE = ITEMS.register("diamond_rake", () -> new RakeToolItem(Tiers.DIAMOND, -3, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, 0.0F, 5))));
+	public static final DeferredItem<RakeToolItem> DIAMOND_RAKE = ITEMS.register("diamond_rake", () -> new RakeToolItem(Tiers.DIAMOND, 3, new Item.Properties().attributes(RakeToolItem.createAttributes(Tiers.WOOD, 0.0F, 5))));
 
 	//Seeds
 	public static final DeferredItem<ItemNameBlockItem> MINT_SEEDS = ITEMS.register("mint_seeds", () -> new ItemNameBlockItem(FarmingRegistry.MINT_CROP.get(), new Item.Properties()));

--- a/src/main/java/com/mrbysco/enhancedfarming/item/RakeToolItem.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/item/RakeToolItem.java
@@ -55,7 +55,7 @@ public class RakeToolItem extends DiggerItem {
 	}
 
 	public void dropSeedsWithChance(ItemStack toolStack, Level level, BlockPos pos) {
-		final int rand = level.random.nextInt(30 / this.dropModifier);
+		final int rand = level.random.nextInt(30 * Math.abs(this.dropModifier));
 		if (!level.isClientSide && rand == 0 && level.getServer() != null) {
 			LootTable table = level.getServer().reloadableRegistries().getLootTable(FarmingLootTables.GAMEPLAY_RAKE_DROPS);
 			LootParams.Builder lootParams = (new LootParams.Builder((ServerLevel) level))

--- a/src/main/java/com/mrbysco/enhancedfarming/item/RakeToolItem.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/item/RakeToolItem.java
@@ -55,7 +55,7 @@ public class RakeToolItem extends DiggerItem {
 	}
 
 	public void dropSeedsWithChance(ItemStack toolStack, Level level, BlockPos pos) {
-		final int rand = level.random.nextInt(30 * Math.abs(this.dropModifier));
+		final int rand = level.random.nextInt(30 / this.dropModifier);
 		if (!level.isClientSide && rand == 0 && level.getServer() != null) {
 			LootTable table = level.getServer().reloadableRegistries().getLootTable(FarmingLootTables.GAMEPLAY_RAKE_DROPS);
 			LootParams.Builder lootParams = (new LootParams.Builder((ServerLevel) level))

--- a/src/main/java/com/mrbysco/enhancedfarming/item/RakeToolItem.java
+++ b/src/main/java/com/mrbysco/enhancedfarming/item/RakeToolItem.java
@@ -55,6 +55,9 @@ public class RakeToolItem extends DiggerItem {
 	}
 
 	public void dropSeedsWithChance(ItemStack toolStack, Level level, BlockPos pos) {
+		if (this.dropModifier == 0) {
+			return;
+		}
 		final int rand = level.random.nextInt(30 / this.dropModifier);
 		if (!level.isClientSide && rand == 0 && level.getServer() != null) {
 			LootTable table = level.getServer().reloadableRegistries().getLootTable(FarmingLootTables.GAMEPLAY_RAKE_DROPS);


### PR DESCRIPTION
Hey there,

While playing after updating to 1.21.1, with NeoForge .89, I noticed that our Rakes were taking 2 strokes to actually turn grass into dirt and nothing was ever dropping out of it, despite having the option enabled in the server config files.

Checking the server logs, I noticed the following exception:

```
[11:29:19] [Server thread/ERROR] [minecraft/ServerPacketListener]: Failed to handle packet net.minecraft.network.protocol.game.ServerboundUseItemOnPacket@413d8ed5, suppressing error
java.lang.IllegalArgumentException: Bound must be positive
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.levelgen.BitRandomSource.nextInt(BitRandomSource.java:22) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/enhancedfarming@6.0.0/com.mrbysco.enhancedfarming.item.RakeToolItem.dropSeedsWithChance(RakeToolItem.java:58) ~[Enhanced-Farming-1.21-6.0.0.jar%23180!/:6.0.0]
	at TRANSFORMER/enhancedfarming@6.0.0/com.mrbysco.enhancedfarming.item.RakeToolItem.useOn(RakeToolItem.java:87) ~[Enhanced-Farming-1.21-6.0.0.jar%23180!/:6.0.0]
	at TRANSFORMER/neoforge@21.1.89/net.neoforged.neoforge.common.CommonHooks.onPlaceItemIntoWorld(CommonHooks.java:614) ~[neoforge-21.1.89-universal.jar%23165!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.item.ItemStack.useOn(ItemStack.java:360) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerPlayerGameMode.useItemOn(ServerPlayerGameMode.java:386) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItemOn(ServerGamePacketListenerImpl.java:1122) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:42) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:10) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:27) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.TickTask.run(TickTask.java:18) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:148) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:23) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:872) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:170) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:122) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:855) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:849) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:132) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:821) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:826) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:712) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:267) ~[server-1.21.1-20240808.144430-srg.jar%23164!/:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

At some point which I don't know when, the `level.random.nextInt` added a change for `bound < 0` to throw an `IllegalArgumentException`, meaning the original `dropModifier` values from the registry file are now invalid.

By setting the values to positive, the logic is still the same, the code is more clearer in terms of semanticas and it does not trigger the problem.

Additionally, it adds the required check for `this.dropModifier == 0` before doing the division, preventing a division by 0 and pilling up errors on server log.